### PR TITLE
[HOPSWORKS-3148] Fix starlette version to <0.18.0

### DIFF
--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -20,6 +20,7 @@ botocore==1.21.18
 psutil>=5.0
 ray[serve]==1.6.0
 grpcio~=1.32.0
+starlette<0.18.0 # starlette 0.18 requires typing-extensions >= 3.10.0 which is not supported by tensorflow 2.4.1 and others
 # google_api_core==1.29.0 # since this library is not used and it creates conflicts with HW python environment, we omit it.
 jmespath==0.10.0
 googleapis_common_protos==1.53.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
