### PR TITLE
Fix protobuf version to ~=3.20.1  in sklearnserver

### DIFF
--- a/python/sklearnserver/setup.py
+++ b/python/sklearnserver/setup.py
@@ -34,7 +34,8 @@ setup(
         "kserve>=0.7.0rc0",
         "scikit-learn == 0.22.2.post1",
         "joblib == 1.1.0",
-        "ray[serve] == 1.6.0"
+        "ray[serve] == 1.6.0",
+        "protobuf ~= 3.20.1"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
