### PR TITLE
[HWORKS-1840] Always checkout scm before switching branch in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,10 @@ properties([
 
 node("local") {
     stage('Clone repository') {
-      if (params.branch == ''){
-        checkout scm
-      } else {
+      // Always clone first: the workspace may be empty on a fresh agent, in which
+      // case the git commands below have no repository to operate on.
+      checkout scm
+      if (params.branch != ''){
         sshagent (credentials: ['id_rsa']) {
           sh """
             git fetch --all


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HWORKS-1840

## Problem

Building the `sklearnserver` image with the `branch` parameter set to `release-0.19.0.0` fails immediately:

```
+ git fetch --all
fatal: not a git repository (or any parent up to mount point /)
ERROR: script returned exit code 128
```

When `branch` is non-empty, the pipeline skipped `checkout scm` entirely and ran the git commands directly in the agent workspace (`/home/jenkinsmaster/workspace/k8s-sklearnserver`). That only works if an earlier run already left a clone there — on a fresh or wiped workspace there is no repository to fetch into. The clone Jenkins makes to read the `Jenkinsfile` lives in a separate `@script` directory on the master, so it does not help.

## Fix

Always run `checkout scm` first so the workspace is a valid repository, and treat `branch` purely as a switch to a different branch afterwards.

## Notes

- The same latent issue exists on `master` and `release-0.15.0.0`, which carry the identical `else` block. Not touched here.
- Until this is merged, the build can be unblocked by re-running the job with `branch` left empty, since the job's SCM already points at `release-0.19.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)