### PR TITLE
[HWORKS-2988] apt-get upgrade -y in the image build

### DIFF
--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -9,7 +9,7 @@ ARG POETRY_HOME=/opt/poetry
 ARG POETRY_VERSION=1.4.0
 
 # Required for building packages for arm64 arch
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python3-dev build-essential
 
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"


### PR DESCRIPTION
Part of [HWORKS-2988](https://hopsworks.atlassian.net/browse/HWORKS-2988) — fleet-wide rollout of the HES-221 / HWORKS-2987 pattern: `apt-get upgrade -y` after `apt-get update` so every build lands at the distro's current security state, independent of base-image or build-cache staleness.

**This repo**: sklearnserver image — 0 apt-fixable today; insurance.

Context: across all our Harbor images, 1,783 findings (30 Critical / 193 High) are fixable today purely by this upgrade at rebuild. A three-way measurement (stale base / fresh base / upgrade) showing why the upgrade line beats fresh-base rebuilds — Canonical's tag rebuilds lag the security archive by ~a month — is documented in HWORKS-2987/2988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HWORKS-2988]: https://hopsworks.atlassian.net/browse/HWORKS-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ